### PR TITLE
Updating code due to removal of "squeeze" argument in Pandas v2.0.0

### DIFF
--- a/inucs.py
+++ b/inucs.py
@@ -1945,7 +1945,7 @@ class CLI:
     def make_heat_map(cls, matrices, chrom, start_region, end_region, output_file: Path, save_only):
         from bokeh.io import show, save
         from bokeh.layouts import layout
-        from bokeh.models import ColorBar, Panel, Tabs, Range1d, LinearColorMapper  # , LogColorMapper
+        from bokeh.models import ColorBar, TabPanel, Tabs, Range1d, LinearColorMapper  # , LogColorMapper
         from bokeh.models import HoverTool, PanTool, WheelZoomTool, BoxZoomTool, ResetTool, SaveTool
         from bokeh.plotting import figure, output_file as save_file
         from bokeh.palettes import Greys, Oranges, Greens, Blues, Purples, Reds
@@ -2064,7 +2064,7 @@ class CLI:
             set_fig_attr(p_norm)
 
             lyt = layout([[p, p_norm]])  # , sizing_mode='fixed')
-            tabs.append(Panel(child=lyt, title=orient_label, closable=False))
+            tabs.append(TabPanel(child=lyt, title=orient_label, closable=False))
 
         #     # Overlaid tab
         #     legend_label = '' if orient == 'all' else ' (' + ','.join(Files.get_strands(orient)) + ')'

--- a/inucs.py
+++ b/inucs.py
@@ -508,7 +508,7 @@ class Chroms(abc.Sequence):
 
     def __init__(self, chrom_list_file, comment: str = S.COMMENT_CHAR, name: str = None):
         chroms = pd.read_csv(chrom_list_file, names=['chrom'], comment=comment,
-                             sep=S.FIELD_SEPARATOR, header=None, usecols=[0], squeeze=True)
+                             sep=S.FIELD_SEPARATOR, header=None, usecols=[0]).squeeze()
 
         if len(chroms) > 0 and chroms[0] in ['chrom', 'chr']:  # remove the first row if it was a header row
             chroms = chroms.drop(index=0).reset_index(drop=True)

--- a/inucs.py
+++ b/inucs.py
@@ -2000,7 +2000,7 @@ class CLI:
         # Bokeh Bug?
         # Setting match_aspect=True, aspect_scale=1 does not work for figure.rect, so setting width and height manually
         figure_args = dict(
-            plot_width=600, plot_height=670, x_axis_location='above', toolbar_location='below',
+            width=600, height=670, x_axis_location='above', toolbar_location='below',
             x_range=x_range, y_range=y_range, tools=tools, x_axis_label='Nucleosome 1', y_axis_label='Nucleosome 2', )
 
         # p_overlaid = figure(


### PR DESCRIPTION
Current version of `inucs prepare` breaks down because `squeeze` argument was deprecated in Pandas v1.4.0 and removed in v2.0.0 ([GH 43427](https://github.com/pandas-dev/pandas/issues/43427)). This PR "fixes #5".